### PR TITLE
replace action ec2_facts to ec2_metadata_facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     - codedeploy
 
 - name: "Get Instance Metadata | ec2"
-  action: ec2_facts
+  action: ec2_metadata_facts
   tags:
     - codedeploy
 


### PR DESCRIPTION
Module ec2_facts has been removed (rename?). 

```
TASK [telusdigital.aws.codedeploy-agent : Get Instance Metadata | ec2] **************************************************************************************************************************************************************
[DEPRECATION WARNING]: ec2_facts is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale.. This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "This module has been removed.  The module documentation for Ansible-2.6 may contain hints for porting"}
```

Tested on 

- CentOS 7
- ansible 2.6.1,  2.7.0
